### PR TITLE
Remind to use Fancy Warp Menu instead of commands

### DIFF
--- a/src/main/java/ca/tirelesstraveler/fancywarpmenu/FancyWarpMenu.java
+++ b/src/main/java/ca/tirelesstraveler/fancywarpmenu/FancyWarpMenu.java
@@ -75,6 +75,7 @@ public class FancyWarpMenu {
         MinecraftForge.EVENT_BUS.register(skyblockJoinListener);
         bar.step("Loading Settings");
         Settings.setConfig(new Configuration(event.getSuggestedConfigurationFile(), modContainer.getVersion()));
+        Settings.setConfigPropertyOrder();
         Settings.syncConfig(true);
         logger = event.getModLog();
         event.getModMetadata().version = modContainer.getVersion();

--- a/src/main/java/ca/tirelesstraveler/fancywarpmenu/data/Settings.java
+++ b/src/main/java/ca/tirelesstraveler/fancywarpmenu/data/Settings.java
@@ -37,6 +37,7 @@ public class Settings {
     private static Configuration config;
     private static boolean warpMenuEnabled;
     private static boolean showIslandLabels;
+    private static boolean remindToUse;
     private static boolean debugModeEnabled;
 
     public static List<IConfigElement> getConfigElements() {
@@ -66,6 +67,11 @@ public class Settings {
         prop.setRequiresWorldRestart(false);
         showIslandLabels = prop.getBoolean(true);
 
+        prop = config.get(CATEGORY_GENERAL, "remindToUse", false);
+        prop.setLanguageKey(FancyWarpMenu.getInstance().getFullLanguageKey("config.remindToUse"));
+        prop.setRequiresWorldRestart(false);
+        remindToUse = prop.getBoolean(false);
+
         prop = config.get(CATEGORY_DEBUG, "debugModeEnabled", false);
         prop.setLanguageKey(FancyWarpMenu.getInstance().getFullLanguageKey("config.developerModeEnabled"));
         prop.setRequiresWorldRestart(false);
@@ -92,7 +98,7 @@ public class Settings {
         return showIslandLabels;
     }
 
-    private Settings() {
-
+    public static boolean isRemindToUse() {
+        return remindToUse;
     }
 }

--- a/src/main/java/ca/tirelesstraveler/fancywarpmenu/data/Settings.java
+++ b/src/main/java/ca/tirelesstraveler/fancywarpmenu/data/Settings.java
@@ -29,6 +29,8 @@ import net.minecraftforge.common.config.Property;
 import net.minecraftforge.fml.client.config.DummyConfigElement;
 import net.minecraftforge.fml.client.config.IConfigElement;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 public class Settings {
@@ -40,7 +42,7 @@ public class Settings {
     private static boolean warpMenuEnabled;
     private static boolean showIslandLabels;
     private static boolean hideWarpLabelsUntilIslandHovered;
-    private static boolean remindToUse;
+    private static boolean suggestWarpMenuOnWarpCommand;
     // Developer settings
     private static boolean debugModeEnabled;
     private static boolean showDebugOverlay;
@@ -57,6 +59,20 @@ public class Settings {
 
     public static void setConfig(Configuration config) {
         Settings.config = config;
+    }
+
+    /**
+     * Sets the order in which config properties are displayed on the settings menu
+     */
+    public static void setConfigPropertyOrder() {
+        List<String> topLevelPropertyOrder = new ArrayList<>();
+        Collections.addAll(topLevelPropertyOrder, "warpMenuEnabled", "showIslandLabels", "hideWarpLabelsUntilIslandHovered", "suggestWarpMenuOnWarpCommand");
+
+        List<String> debugPropertyOrder = new ArrayList<>();
+        Collections.addAll(debugPropertyOrder, "debugModeEnabled", "showDebugOverlay", "drawBorders");
+
+        config.setCategoryPropertyOrder(CATEGORY_GENERAL, topLevelPropertyOrder);
+        config.setCategoryPropertyOrder(CATEGORY_DEBUG, debugPropertyOrder);
     }
 
     public static void syncConfig(boolean load) {
@@ -81,15 +97,19 @@ public class Settings {
         prop.setRequiresWorldRestart(false);
         hideWarpLabelsUntilIslandHovered = prop.getBoolean(false);
 
-        prop = config.get(CATEGORY_GENERAL, "remindToUse", false);
-        prop.setLanguageKey(FancyWarpMenu.getInstance().getFullLanguageKey("config.remindToUse"));
+        prop = config.get(CATEGORY_GENERAL, "suggestWarpMenuOnWarpCommand", false);
+        prop.setLanguageKey(FancyWarpMenu.getInstance().getFullLanguageKey("config.suggestWarpMenuOnWarpCommand"));
         prop.setRequiresWorldRestart(false);
-        remindToUse = prop.getBoolean(false);
+        suggestWarpMenuOnWarpCommand = prop.getBoolean(false);
 
         prop = config.get(CATEGORY_DEBUG, "debugModeEnabled", false);
         prop.setLanguageKey(FancyWarpMenu.getInstance().getFullLanguageKey("config.developerModeEnabled"));
         prop.setRequiresWorldRestart(false);
         debugModeEnabled = prop.getBoolean(false);
+
+        if (!debugModeEnabled && Boolean.getBoolean("fancywarpmenu.debugRendering")) {
+            prop.set(true);
+        }
 
         prop = config.get(CATEGORY_DEBUG, "showDebugOverlay", true);
         prop.setLanguageKey(FancyWarpMenu.getInstance().getFullLanguageKey("config.showDebugOverlay"));
@@ -100,10 +120,6 @@ public class Settings {
         prop.setLanguageKey(FancyWarpMenu.getInstance().getFullLanguageKey("config.drawBorders"));
         prop.setRequiresWorldRestart(false);
         drawBorders = prop.getBoolean(true);
-
-        if (!debugModeEnabled && Boolean.getBoolean("fancywarpmenu.debugRendering")) {
-            prop.set(true);
-        }
 
         if (config.hasChanged()) {
             config.save();
@@ -120,6 +136,10 @@ public class Settings {
 
     public static boolean shouldHideWarpLabelsUntilIslandHovered() {
         return hideWarpLabelsUntilIslandHovered;
+    }
+
+    public static boolean shouldSuggestWarpMenuOnWarpCommand() {
+        return suggestWarpMenuOnWarpCommand;
     }
 
     public static boolean isDebugModeEnabled() {
@@ -142,9 +162,5 @@ public class Settings {
     public static void setDrawBorders(boolean drawBorders) {
         config.get(CATEGORY_DEBUG, "drawBorders", true).set(drawBorders);
         syncConfig(false);
-    }
-
-    public static boolean shouldRemindToUse() {
-        return remindToUse;
     }
 }

--- a/src/main/java/ca/tirelesstraveler/fancywarpmenu/data/Settings.java
+++ b/src/main/java/ca/tirelesstraveler/fancywarpmenu/data/Settings.java
@@ -98,7 +98,7 @@ public class Settings {
         return showIslandLabels;
     }
 
-    public static boolean isRemindToUse() {
+    public static boolean shouldRemindToUse() {
         return remindToUse;
     }
 }

--- a/src/main/java/ca/tirelesstraveler/fancywarpmenu/listeners/WarpMenuListener.java
+++ b/src/main/java/ca/tirelesstraveler/fancywarpmenu/listeners/WarpMenuListener.java
@@ -34,9 +34,7 @@ import net.minecraft.client.gui.inventory.GuiChest;
 import net.minecraft.crash.CrashReport;
 import net.minecraft.inventory.ContainerChest;
 import net.minecraft.launchwrapper.Launch;
-import net.minecraft.util.ChatComponentText;
-import net.minecraft.util.ReportedException;
-import net.minecraft.util.StringUtils;
+import net.minecraft.util.*;
 import net.minecraftforge.client.event.ClientChatReceivedEvent;
 import net.minecraftforge.client.event.GuiScreenEvent;
 import net.minecraftforge.fml.client.event.ConfigChangedEvent;
@@ -123,12 +121,12 @@ public class WarpMenuListener extends ChannelOutboundHandlerAdapter {
                     mc.ingameGUI.getChatGUI().addToSentMessages(chatMessage);
                     event.setCanceled(true);
                 } else {
-                    if (Settings.shouldRemindToUse()) {
-                        if (isWarpingCommand(chatMessage)) {
-                            mc.thePlayer.addChatMessage(new ChatComponentText("§cReminder to use Fancy Warp Menu instead!"));
+                    if (Settings.shouldSuggestWarpMenuOnWarpCommand()) {
+                        if (isWarpCommand(chatMessage)) {
+                            mc.thePlayer.addChatMessage(new ChatComponentTranslation(FancyWarpMenu.getInstance().getFullLanguageKey("messages.useWarpMenuInsteadOfCommand"))
+                                    .setChatStyle(new ChatStyle().setColor(EnumChatFormatting.RED)));
                         }
                     }
-
                 }
             } catch (Throwable e) {
                 throw new ReportedException(CrashReport.makeCrashReport(e, "Failed to get chat message from GuiChat"));
@@ -136,7 +134,7 @@ public class WarpMenuListener extends ChannelOutboundHandlerAdapter {
         }
     }
 
-    private static boolean isWarpingCommand(String chatMessage) {
+    private static boolean isWarpCommand(String chatMessage) {
         if (chatMessage.startsWith("/warp ")) return true;
 
         switch (chatMessage) {

--- a/src/main/java/ca/tirelesstraveler/fancywarpmenu/listeners/WarpMenuListener.java
+++ b/src/main/java/ca/tirelesstraveler/fancywarpmenu/listeners/WarpMenuListener.java
@@ -124,8 +124,7 @@ public class WarpMenuListener extends ChannelOutboundHandlerAdapter {
                     event.setCanceled(true);
                 } else {
                     if (Settings.isRemindToUse()) {
-                        if (chatMessage.startsWith("/warp ") || chatMessage.equals("/is") || chatMessage.equals("/hub")) {
-//                            event.setCanceled(true);
+                        if (isWarpingCommand(chatMessage)) {
                             mc.thePlayer.addChatMessage(new ChatComponentText("§cReminder to use Fancy Warp Menu instead!"));
                         }
                     }
@@ -134,6 +133,21 @@ public class WarpMenuListener extends ChannelOutboundHandlerAdapter {
             } catch (Throwable e) {
                 throw new ReportedException(CrashReport.makeCrashReport(e, "Failed to get chat message from GuiChat"));
             }
+        }
+    }
+
+    private static boolean isWarpingCommand(String chatMessage) {
+        if (chatMessage.startsWith("/warp ")) return true;
+
+        switch (chatMessage) {
+            case "/is":
+            case "/hub":
+            case "/warpforge":
+            case "/savethejerrys":
+                return true;
+
+            default:
+                return false;
         }
     }
 

--- a/src/main/java/ca/tirelesstraveler/fancywarpmenu/listeners/WarpMenuListener.java
+++ b/src/main/java/ca/tirelesstraveler/fancywarpmenu/listeners/WarpMenuListener.java
@@ -34,6 +34,7 @@ import net.minecraft.client.gui.inventory.GuiChest;
 import net.minecraft.crash.CrashReport;
 import net.minecraft.inventory.ContainerChest;
 import net.minecraft.launchwrapper.Launch;
+import net.minecraft.util.ChatComponentText;
 import net.minecraft.util.ReportedException;
 import net.minecraft.util.StringUtils;
 import net.minecraftforge.client.event.ClientChatReceivedEvent;
@@ -64,7 +65,7 @@ public class WarpMenuListener extends ChannelOutboundHandlerAdapter {
     static {
         mc = Minecraft.getMinecraft();
         modInstance = FancyWarpMenu.getInstance();
-        
+
         try {
             String inputFieldName = (Boolean) Launch.blackboard.get("fml.deobfuscatedEnvironment") ? "inputField" : "field_146415_a";
             chatInputField = GuiChat.class.getDeclaredField(inputFieldName);
@@ -121,6 +122,14 @@ public class WarpMenuListener extends ChannelOutboundHandlerAdapter {
                     mc.displayGuiScreen(warpScreen);
                     mc.ingameGUI.getChatGUI().addToSentMessages(chatMessage);
                     event.setCanceled(true);
+                } else {
+                    if (Settings.isRemindToUse()) {
+                        if (chatMessage.startsWith("/warp ") || chatMessage.equals("/is") || chatMessage.equals("/hub")) {
+//                            event.setCanceled(true);
+                            mc.thePlayer.addChatMessage(new ChatComponentText("§cReminder to use Fancy Warp Menu instead!"));
+                        }
+                    }
+
                 }
             } catch (Throwable e) {
                 throw new ReportedException(CrashReport.makeCrashReport(e, "Failed to get chat message from GuiChat"));
@@ -138,22 +147,22 @@ public class WarpMenuListener extends ChannelOutboundHandlerAdapter {
                 && Mouse.getEventButton() == 0
                 && Mouse.getEventButtonState()
                 && event.gui instanceof GuiChest) {
-                GuiChest guiChest = (GuiChest) event.gui;
+            GuiChest guiChest = (GuiChest) event.gui;
 
-                if (guiChest.inventorySlots instanceof ContainerChest) {
-                    ContainerChest container = (ContainerChest) guiChest.inventorySlots;
+            if (guiChest.inventorySlots instanceof ContainerChest) {
+                ContainerChest container = (ContainerChest) guiChest.inventorySlots;
 
-                    if (container.getLowerChestInventory() != null
-                            && container.getLowerChestInventory().getDisplayName() != null
-                            && container.getLowerChestInventory().getDisplayName().getUnformattedText().equals("SkyBlock Menu")
-                            && guiChest.getSlotUnderMouse() != null
-                            && guiChest.getSlotUnderMouse().getSlotIndex() == 47
-                            // Rift SkyBlock Menu has a return to hub button in slot 47
-                            && StringUtils.stripControlCodes(guiChest.getSlotUnderMouse().getStack().getDisplayName()).equals("Fast Travel")) {
-                        mc.displayGuiScreen(new GuiFancyWarp());
-                        event.setCanceled(true);
-                    }
+                if (container.getLowerChestInventory() != null
+                        && container.getLowerChestInventory().getDisplayName() != null
+                        && container.getLowerChestInventory().getDisplayName().getUnformattedText().equals("SkyBlock Menu")
+                        && guiChest.getSlotUnderMouse() != null
+                        && guiChest.getSlotUnderMouse().getSlotIndex() == 47
+                        // Rift SkyBlock Menu has a return to hub button in slot 47
+                        && StringUtils.stripControlCodes(guiChest.getSlotUnderMouse().getStack().getDisplayName()).equals("Fast Travel")) {
+                    mc.displayGuiScreen(new GuiFancyWarp());
+                    event.setCanceled(true);
                 }
+            }
         }
     }
 

--- a/src/main/java/ca/tirelesstraveler/fancywarpmenu/listeners/WarpMenuListener.java
+++ b/src/main/java/ca/tirelesstraveler/fancywarpmenu/listeners/WarpMenuListener.java
@@ -123,7 +123,7 @@ public class WarpMenuListener extends ChannelOutboundHandlerAdapter {
                     mc.ingameGUI.getChatGUI().addToSentMessages(chatMessage);
                     event.setCanceled(true);
                 } else {
-                    if (Settings.isRemindToUse()) {
+                    if (Settings.shouldRemindToUse()) {
                         if (isWarpingCommand(chatMessage)) {
                             mc.thePlayer.addChatMessage(new ChatComponentText("§cReminder to use Fancy Warp Menu instead!"));
                         }

--- a/src/main/resources/assets/fancywarpmenu/lang/en_US.lang
+++ b/src/main/resources/assets/fancywarpmenu/lang/en_US.lang
@@ -5,10 +5,11 @@ fancywarpmenu.config.title=Fancy Warp Menu Settings
 fancywarpmenu.config.warpMenuEnabled=Enable Fancy Warp Menu
 fancywarpmenu.config.warpMenuEnabled.tooltip=Replace the default warp menu with the Fancy Warp Menu
 fancywarpmenu.config.showIslandLabels=Show Island Names
-fancywarpmenu.config.remindToUse=Remind to use Fancy Warp Menu instead of commands
 fancywarpmenu.config.showIslandLabels.tooltip=Show each island's name below its picture
 fancywarpmenu.config.hideWarpLabelsUntilIslandHovered=Hide Warp Labels Until Island Hovered
 fancywarpmenu.config.hideWarpLabelsUntilIslandHovered.tooltip=Hide the island's warp button labels until the mouse is hovering over the island
+fancywarpmenu.config.suggestWarpMenuOnWarpCommand=Reminders to Use Warp Menu
+fancywarpmenu.config.suggestWarpMenuOnWarpCommand.tooltip=Show reminders to use the fancy warp menu when the player uses a warp command
 fancywarpmenu.config.developerModeEnabled=Enable Developer Mode
 fancywarpmenu.config.developerModeEnabled.tooltip=Enable all developer features
 fancywarpmenu.config.showDebugOverlay=Show Debug Overlay
@@ -20,6 +21,8 @@ fancywarpmenu.config.drawBorders.tooltip=Show borders around island and warp but
 fancywarpmenu.key.openMenu=Open Warp Menu
 
 fancywarpmenu.key.categories.fancyWarpMenu=Fancy Warp Menu
+
+fancywarpmenu.messages.useWarpMenuInsteadOfCommand=Reminder to use Fancy Warp Menu instead!
 
 fancywarpmenu.errors.notUnlocked=Not Unlocked
 fancywarpmenu.errors.unknownDestination=Unknown Destination

--- a/src/main/resources/assets/fancywarpmenu/lang/en_US.lang
+++ b/src/main/resources/assets/fancywarpmenu/lang/en_US.lang
@@ -1,6 +1,7 @@
 fancywarpmenu.config.title=Fancy Warp Menu Settings
 fancywarpmenu.config.warpMenuEnabled=Enable Fancy Warp Menu
 fancywarpmenu.config.showIslandLabels=Show Island Names
+fancywarpmenu.config.remindToUse=Remind to use Fancy Warp Menu instead of commands
 fancywarpmenu.config.developerModeEnabled=Enable Developer Mode
 
 fancywarpmenu.key.openMenu=Open Warp Menu


### PR DESCRIPTION
Sends a chat message if the player attempts to warp using `/warp` or `/hub` or `/is` instead of using the fancy warp menu.
The option is default disabled.
I don't understand why the new setting is on top of the others. Is there a way to define the setting order without the need to create a new category?

![image](https://github.com/ILikePlayingGames/FancyWarpMenu/assets/24389977/10ac8255-5cd7-4d6b-9b35-2ea954688885)
![image](https://github.com/ILikePlayingGames/FancyWarpMenu/assets/24389977/af2ec13c-778d-4992-8303-a62b86e420ac)

