### PR TITLE
Fixed Suggest Warp Menu

### DIFF
--- a/src/main/java/ca/tirelesstraveler/fancywarpmenu/gui/GuiFancyWarp.java
+++ b/src/main/java/ca/tirelesstraveler/fancywarpmenu/gui/GuiFancyWarp.java
@@ -33,6 +33,8 @@ import net.minecraft.client.gui.ScaledResolution;
 import net.minecraft.client.resources.I18n;
 import net.minecraft.network.play.client.C01PacketChatMessage;
 import net.minecraft.util.EnumChatFormatting;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.lwjgl.input.Keyboard;
 
 import java.awt.*;
@@ -45,6 +47,7 @@ public class GuiFancyWarp extends GuiScreen {
     private static final long WARP_FAIL_COOL_DOWN = 500L;
     /** The amount of time in ms that the error message remains on-screen after a failed warp attempt */
     private static final long WARP_FAIL_TOOLTIP_DISPLAY_TIME = 2000L;
+    private static final Logger logger = LogManager.getLogger();
 
     private ScaledResolution res;
     private float gridUnitWidth;
@@ -177,7 +180,7 @@ public class GuiFancyWarp extends GuiScreen {
                 mc.ingameGUI.getChatGUI().addToSentMessages(warpCommand);
                 mc.thePlayer.sendQueue.addToSendQueue(new C01PacketChatMessage(warpCommand));
             } catch (Exception e) {
-                new RuntimeException("Error while trying to send chat message with '" + warpCommand + "'", e).printStackTrace();
+                logger.error(String.format("Failed to send command \"%s\": %s", warpCommand, e.getMessage()), e);
             }
         }
     }

--- a/src/main/java/ca/tirelesstraveler/fancywarpmenu/gui/GuiFancyWarp.java
+++ b/src/main/java/ca/tirelesstraveler/fancywarpmenu/gui/GuiFancyWarp.java
@@ -31,6 +31,7 @@ import net.minecraft.client.gui.GuiButton;
 import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.client.gui.ScaledResolution;
 import net.minecraft.client.resources.I18n;
+import net.minecraft.network.play.client.C01PacketChatMessage;
 import net.minecraft.util.EnumChatFormatting;
 import org.lwjgl.input.Keyboard;
 
@@ -171,7 +172,13 @@ public class GuiFancyWarp extends GuiScreen {
     protected void actionPerformed(GuiButton button) {
         // Block repeat clicks if the last warp failed
         if (button instanceof GuiWarpButton && Minecraft.getSystemTime() > warpFailCoolDownExpiryTime) {
-            sendChatMessage(((GuiWarpButton)button).getWarpCommand());
+            String warpCommand = ((GuiWarpButton) button).getWarpCommand();
+            try {
+                mc.ingameGUI.getChatGUI().addToSentMessages(warpCommand);
+                mc.thePlayer.sendQueue.addToSendQueue(new C01PacketChatMessage(warpCommand));
+            } catch (Exception e) {
+                new RuntimeException("Error while trying to send chat message with '" + warpCommand + "'", e).printStackTrace();
+            }
         }
     }
 

--- a/src/main/java/ca/tirelesstraveler/fancywarpmenu/hooks/EntityPlayerSPHook.java
+++ b/src/main/java/ca/tirelesstraveler/fancywarpmenu/hooks/EntityPlayerSPHook.java
@@ -1,0 +1,27 @@
+package ca.tirelesstraveler.fancywarpmenu.hooks;
+
+import ca.tirelesstraveler.fancywarpmenu.FancyWarpMenu;
+import ca.tirelesstraveler.fancywarpmenu.data.Settings;
+import ca.tirelesstraveler.fancywarpmenu.gui.GuiFancyWarp;
+import ca.tirelesstraveler.fancywarpmenu.listeners.WarpMenuListener;
+import net.minecraft.client.Minecraft;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import java.util.Locale;
+
+public class EntityPlayerSPHook {
+    public static void onSendChatMessage(String message, CallbackInfo ci) {
+        String lowerCaseMessage = message.toLowerCase(Locale.US);
+        if (Settings.isWarpMenuEnabled() && FancyWarpMenu.getInstance().isPlayerOnSkyBlock() && lowerCaseMessage.startsWith("/")) {
+            if (lowerCaseMessage.equals("/warp")) {
+                GuiFancyWarp warpScreen = new GuiFancyWarp();
+                WarpMenuListener.setWarpScreen(warpScreen);
+                Minecraft.getMinecraft().displayGuiScreen(warpScreen);
+                ci.cancel();
+            } else if (Settings.shouldSuggestWarpMenuOnWarpCommand() &&
+                    WarpMenuListener.isWarpCommand(lowerCaseMessage)) {
+                WarpMenuListener.sendReminderToUseWarpScreen();
+            }
+        }
+    }
+}

--- a/src/main/java/ca/tirelesstraveler/fancywarpmenu/listeners/WarpMenuListener.java
+++ b/src/main/java/ca/tirelesstraveler/fancywarpmenu/listeners/WarpMenuListener.java
@@ -25,6 +25,7 @@ package ca.tirelesstraveler.fancywarpmenu.listeners;
 import ca.tirelesstraveler.fancywarpmenu.FancyWarpMenu;
 import ca.tirelesstraveler.fancywarpmenu.commands.DummyWarpCommand;
 import ca.tirelesstraveler.fancywarpmenu.data.Settings;
+import ca.tirelesstraveler.fancywarpmenu.data.WarpMessages;
 import ca.tirelesstraveler.fancywarpmenu.gui.GuiFancyWarp;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelOutboundHandlerAdapter;
@@ -43,6 +44,8 @@ import net.minecraftforge.fml.client.event.ConfigChangedEvent;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.common.gameevent.InputEvent;
 import org.lwjgl.input.Mouse;
+
+import java.util.Map;
 
 /**
  * General purpose event listener
@@ -69,7 +72,10 @@ public class WarpMenuListener extends ChannelOutboundHandlerAdapter {
             if (modInstance.getWarpMessages().getWarpSuccessMessages().contains(unformattedText)) {
                 mc.displayGuiScreen(null);
             } else if (modInstance.getWarpMessages().getWarpFailMessages().containsKey(unformattedText)) {
-                warpScreen.onWarpFail(modInstance.getWarpMessages().getWarpFailMessages().get(unformattedText));
+                WarpMessages warpMessages = modInstance.getWarpMessages();
+                Map<String, String> warpFailMessages = warpMessages.getWarpFailMessages();
+                String failMessageKey = warpFailMessages.get(unformattedText);
+                warpScreen.onWarpFail(failMessageKey);
             }
         }
     }
@@ -163,7 +169,8 @@ public class WarpMenuListener extends ChannelOutboundHandlerAdapter {
      * @param commandName name of the command the player sent, excluding the slash and any arguments
      */
     public static boolean isWarpCommand(String commandName) {
-        return modInstance.getWarpCommandVariants().contains(commandName);
+        String baseCommand = commandName.substring(1).split(" ")[0];
+        return modInstance.getWarpCommandVariants().contains(baseCommand);
     }
 
     public static void setWarpScreen(GuiFancyWarp warpScreen) {

--- a/src/main/java/ca/tirelesstraveler/fancywarpmenu/mixin/MixinEntityPlayerSP.java
+++ b/src/main/java/ca/tirelesstraveler/fancywarpmenu/mixin/MixinEntityPlayerSP.java
@@ -22,18 +22,12 @@
 
 package ca.tirelesstraveler.fancywarpmenu.mixin;
 
-import ca.tirelesstraveler.fancywarpmenu.FancyWarpMenu;
-import ca.tirelesstraveler.fancywarpmenu.data.Settings;
-import ca.tirelesstraveler.fancywarpmenu.gui.GuiFancyWarp;
-import ca.tirelesstraveler.fancywarpmenu.listeners.WarpMenuListener;
-import net.minecraft.client.Minecraft;
+import ca.tirelesstraveler.fancywarpmenu.hooks.EntityPlayerSPHook;
 import net.minecraft.client.entity.EntityPlayerSP;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-
-import java.util.Locale;
 
 /**
  * This mixin intercepts warp menu requests that use {@link EntityPlayerSP#sendChatMessage(String)} to send
@@ -45,18 +39,6 @@ import java.util.Locale;
 public class MixinEntityPlayerSP {
     @Inject(method = "sendChatMessage", at = @At("HEAD"), cancellable = true, require = 1)
     public void onSendChatMessage(String message, CallbackInfo ci) {
-        String lowerCaseMessage = message.toLowerCase(Locale.US);
-
-        if (Settings.isWarpMenuEnabled() && FancyWarpMenu.getInstance().isPlayerOnSkyBlock() && lowerCaseMessage.startsWith("/")) {
-            if (lowerCaseMessage.equals("/warp")) {
-                GuiFancyWarp warpScreen = new GuiFancyWarp();
-                WarpMenuListener.setWarpScreen(warpScreen);
-                Minecraft.getMinecraft().displayGuiScreen(warpScreen);
-                ci.cancel();
-            } else if (Settings.shouldSuggestWarpMenuOnWarpCommand() &&
-                    WarpMenuListener.isWarpCommand(lowerCaseMessage.substring(1, lowerCaseMessage.indexOf(' ')))) {
-                WarpMenuListener.sendReminderToUseWarpScreen();
-            }
-        }
+        EntityPlayerSPHook.onSendChatMessage(message, ci);
     }
 }

--- a/src/main/resources/assets/fancywarpmenu/data/islands.json
+++ b/src/main/resources/assets/fancywarpmenu/data/islands.json
@@ -356,6 +356,7 @@
   "warpCommandVariants": [
     "warp",
     "is",
+    "hub",
     "warpforge",
     "savethejerrys"
   ]


### PR DESCRIPTION
I crashed with an unreadable stack trace when clicking on the Jerry's Workshop inside the fancy warp menu.
I debugged the code and found multiple problems with the latest rewrite of the suggestWarpMenuOnWarpCommand logic.
This PR should fix all of them.

First, the error occurred inside the mixin code. Since we were not using a hook class previously, I could not find the corresponding lines of the error.
Therefore, I created an `EntityPlayerSPHook` class to properly read and understand error logs that contain mixin code in the future.

My crash happened because  `lowerCaseMessage` "/savethejerrys" doesn't contain `" "` and therefore `lowerCaseMessage.substring(1, lowerCaseMessage.indexOf(' '))` threw an error.
I fixed it by replacing the logic with `split(" ")`.

I found an additional logical error. We checked the clicked buttons inside the fancy warp menu against the `suggestWarpMenuOnWarpCommand` filter, clicking on them sends wrongly the "use fancy warp menu" message.
To fix this, I replaced the `player.sendChatMessage` call inside `GuiFancyWarp.actionPerformed` with `addToSentMessages` and `addToSendQueue(C01PacketChatMessage)`.

While debugging, I got a NullPointerException (only once) in `WarpMenuListener.onChatMessageReceived`.
I have split up the method calls into multiple local variables to find the correct line that calls the null object.
I could not reproduce this NPE, but the changed code will make finding the NPE (should it happen again) easier in the future.

Furthermore, I re-added `/hub` to the `warpCommandVariants` list. I thought this got lost while porting the code into the JSON file.