### PR TITLE
Updated mcmod.info so it builds into a proper json format

### DIFF
--- a/src/main/resources/mcmod.info
+++ b/src/main/resources/mcmod.info
@@ -2,7 +2,7 @@
 	{
 		"modid": "fancywarpmenu",
 		"name": "Fancy Warp Menu",
-		"description": "A recreation of the fancy warp menu from SkyblockAddons\nSupport: https://discord.gg/tXFf9umfA9\nLicenses: https://github.com/ILikePlayingGames/FancyWarpMenu/wiki/Licenses",
+		"description": "A recreation of the fancy warp menu from SkyblockAddons\\nSupport: https://discord.gg/tXFf9umfA9\\nLicenses: https://github.com/ILikePlayingGames/FancyWarpMenu/wiki/Licenses",
 		"version": "${version}",
 		"mcversion": "${mcversion}",
 		"url": "https://github.com/ILikePlayingGames/FancyWarpMenu",


### PR DESCRIPTION
The old mcmod.info did not build into a proper json format.

Old mcmod.info from decompiled .jar 
```json
[
	{
		"modid": "fancywarpmenu",
		"name": "Fancy Warp Menu",
		"description": "A recreation of the fancy warp menu from SkyblockAddons
Support: https://discord.gg/tXFf9umfA9
Licenses: https://github.com/ILikePlayingGames/FancyWarpMenu/wiki/Licenses",
		"version": "1.0+96",
		"mcversion": "1.8.9",
		"url": "https://github.com/ILikePlayingGames/FancyWarpMenu",
		"authorList": [
			"TirelessTraveler"
		],
		"credits": "Nea89, SBA contributors, Schlaumeyer, Fandom SkyBlock Wiki",
		"logoFile": "assets/fancywarpmenu/textures/gui/Logo.png",
		"screenshots": [],
		"dependencies": []
	}

]
```

<img width="844" alt="image" src="https://github.com/ILikePlayingGames/FancyWarpMenu/assets/83100266/470abce8-a639-491c-8051-6c9a47b5b9cc">



New mcmod.info from decompiled .jar
```json
[
	{
		"modid": "fancywarpmenu",
		"name": "Fancy Warp Menu",
		"description": "A recreation of the fancy warp menu from SkyblockAddons\nSupport: https://discord.gg/tXFf9umfA9\nLicenses: https://github.com/ILikePlayingGames/FancyWarpMenu/wiki/Licenses",
		"version": "1.0",
		"mcversion": "1.8.9",
		"url": "https://github.com/ILikePlayingGames/FancyWarpMenu",
		"authorList": [
			"TirelessTraveler"
		],
		"credits": "Nea89, SBA contributors, Schlaumeyer, Fandom SkyBlock Wiki",
		"logoFile": "assets/fancywarpmenu/textures/gui/Logo.png",
		"screenshots": [],
		"dependencies": []
	}

]
```

<img width="915" alt="image" src="https://github.com/ILikePlayingGames/FancyWarpMenu/assets/83100266/5ae33e44-b365-48bf-84c5-19066325ab32">


Still formats correctly:
<img width="728" alt="image" src="https://github.com/ILikePlayingGames/FancyWarpMenu/assets/83100266/932ec616-e08f-4198-9e14-707eeb34e4ea">


Was trying to get it to work in a discord bot and it wouldn't convert to json